### PR TITLE
Add Python SDK deployment example

### DIFF
--- a/examples/overlay-cni-public/README.md
+++ b/examples/overlay-cni-public/README.md
@@ -1,0 +1,70 @@
+# Deploy AKS with Azure CNI Overlay and Public API Server
+
+This example demonstrates how to create an AKS cluster using the Azure CNI overlay network plugin. The API server remains publicly accessible via the standard load balancer.
+
+## Requirements
+
+* [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) `2.49` or newer
+* `kubectl`
+* An Azure subscription with permission to create resource groups and AKS clusters
+
+## Usage
+
+Set the following environment variables or modify them directly in the script:
+
+```bash
+export AKS_RG=myOverlayRG
+export AKS_NAME=myOverlayCluster
+export AKS_LOCATION=eastus
+export AKS_NODE_COUNT=3
+export AKS_NODE_SIZE=Standard_DS2_v2
+export AKS_POD_CIDR=10.240.0.0/16
+```
+
+Run the Bash deployment script:
+
+```bash
+./deploy-overlay.sh
+```
+
+The script will create the resource group, deploy the cluster and configure your kubeconfig. After it completes you can verify the deployment with `kubectl get nodes`.
+
+### Using the Azure Python SDK
+
+Alternatively you can deploy using the provided Python script. Ensure the
+[`azure-identity`](https://pypi.org/project/azure-identity/) and
+[`azure-mgmt-containerservice`](https://pypi.org/project/azure-mgmt-containerservice/)
+packages are installed, then run:
+
+```bash
+python deploy_overlay.py
+```
+
+## Deploy using Bicep
+
+For repeatable deployments you can use the accompanying `main.bicep` file. It
+creates the resource group, a Log Analytics workspace for monitoring and the AKS
+cluster with Azure CNI overlay networking.
+
+Deploy the Bicep template at the subscription scope:
+
+```bash
+az deployment sub create \
+  --location $AKS_LOCATION \
+  --template-file main.bicep \
+  --parameters resourceGroupName=$AKS_RG \
+               clusterName=$AKS_NAME \
+               location=$AKS_LOCATION \
+               nodeCount=$AKS_NODE_COUNT \
+               nodeSize=$AKS_NODE_SIZE \
+               podCidr=$AKS_POD_CIDR
+```
+
+After deployment, fetch credentials with:
+
+```bash
+az aks get-credentials --resource-group $AKS_RG --name $AKS_NAME
+```
+
+
+

--- a/examples/overlay-cni-public/deploy-overlay.sh
+++ b/examples/overlay-cni-public/deploy-overlay.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Deploy an AKS cluster using Azure CNI overlay with a public API server.
+# Requires Azure CLI and kubectl to be installed and logged in.
+
+set -euo pipefail
+
+# Configuration. These can be overridden with environment variables.
+RESOURCE_GROUP="${AKS_RG:-aks-overlay-rg}"
+CLUSTER_NAME="${AKS_NAME:-aks-overlay}"
+LOCATION="${AKS_LOCATION:-eastus}"
+NODE_SIZE="${AKS_NODE_SIZE:-Standard_DS2_v2}"
+NODE_COUNT="${AKS_NODE_COUNT:-3}"
+POD_CIDR="${AKS_POD_CIDR:-10.240.0.0/16}"
+
+# Create resource group if it doesn't exist
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION"
+
+# Create the AKS cluster
+az aks create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" \
+  --location "$LOCATION" \
+  --node-count "$NODE_COUNT" \
+  --node-vm-size "$NODE_SIZE" \
+  --enable-managed-identity \
+  --network-plugin azure \
+  --network-plugin-mode overlay \
+  --pod-cidr "$POD_CIDR" \
+  --load-balancer-sku standard \
+  --generate-ssh-keys
+
+# Fetch cluster credentials
+az aks get-credentials --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME"
+
+echo "Cluster $CLUSTER_NAME deployed in $RESOURCE_GROUP."
+

--- a/examples/overlay-cni-public/deploy_overlay.py
+++ b/examples/overlay-cni-public/deploy_overlay.py
@@ -1,0 +1,74 @@
+import os
+from azure.identity import DefaultAzureCredential
+from azure.mgmt.resource import ResourceManagementClient
+from azure.mgmt.containerservice import ContainerServiceClient
+from azure.mgmt.containerservice.models import (
+    ManagedCluster,
+    ManagedClusterAgentPoolProfile,
+    ManagedClusterIdentity,
+    ManagedClusterAddonProfile,
+    ContainerServiceNetworkProfile,
+)
+
+
+def main():
+    subscription_id = os.environ.get("AZURE_SUBSCRIPTION_ID")
+    if not subscription_id:
+        raise SystemExit("AZURE_SUBSCRIPTION_ID environment variable is required")
+
+    credential = DefaultAzureCredential()
+
+    rg_name = os.environ.get("AKS_RG", "aks-overlay-rg")
+    location = os.environ.get("AKS_LOCATION", "eastus")
+    cluster_name = os.environ.get("AKS_NAME", "aks-overlay")
+    node_size = os.environ.get("AKS_NODE_SIZE", "Standard_DS2_v2")
+    node_count = int(os.environ.get("AKS_NODE_COUNT", "3"))
+    pod_cidr = os.environ.get("AKS_POD_CIDR", "10.240.0.0/16")
+
+    resource_client = ResourceManagementClient(credential, subscription_id)
+    resource_client.resource_groups.create_or_update(
+        rg_name, {"location": location}
+    )
+
+    container_client = ContainerServiceClient(credential, subscription_id)
+
+    agent_pool = ManagedClusterAgentPoolProfile(
+        name="nodepool1",
+        count=node_count,
+        vm_size=node_size,
+        os_type="Linux",
+        mode="System",
+        type="VirtualMachineScaleSets",
+    )
+
+    network_profile = ContainerServiceNetworkProfile(
+        network_plugin="azure",
+        network_plugin_mode="overlay",
+        pod_cidr=pod_cidr,
+        load_balancer_sku="standard",
+    )
+
+    addon_profile = ManagedClusterAddonProfile(
+        enabled=True,
+        config={},
+    )
+
+    managed_cluster = ManagedCluster(
+        location=location,
+        dns_prefix=cluster_name,
+        agent_pool_profiles=[agent_pool],
+        network_profile=network_profile,
+        identity=ManagedClusterIdentity(type="SystemAssigned"),
+        addon_profiles={"omsAgent": addon_profile},
+    )
+
+    poller = container_client.managed_clusters.begin_create_or_update(
+        rg_name, cluster_name, managed_cluster
+    )
+    poller.result()
+
+    print(f"Cluster {cluster_name} deployed in {rg_name}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/overlay-cni-public/main.bicep
+++ b/examples/overlay-cni-public/main.bicep
@@ -1,0 +1,61 @@
+targetScope = 'subscription'
+
+param resourceGroupName string = 'aks-overlay-rg'
+param location string = 'eastus'
+param clusterName string = 'aks-overlay'
+param nodeCount int = 3
+param nodeSize string = 'Standard_DS2_v2'
+param podCidr string = '10.240.0.0/16'
+
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: '${clusterName}-logs'
+  location: location
+  sku: {
+    name: 'PerGB2018'
+  }
+  retentionInDays: 30
+}
+
+resource aks 'Microsoft.ContainerService/managedClusters@2023-10-01' = {
+  name: clusterName
+  location: location
+  scope: rg
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    dnsPrefix: clusterName
+    agentPoolProfiles: [
+      {
+        name: 'nodepool1'
+        count: nodeCount
+        vmSize: nodeSize
+        osType: 'Linux'
+        mode: 'System'
+        type: 'VirtualMachineScaleSets'
+      }
+    ]
+    networkProfile: {
+      networkPlugin: 'azure'
+      networkPluginMode: 'overlay'
+      podCidr: podCidr
+      loadBalancerSku: 'standard'
+    }
+    addonProfiles: {
+      omsAgent: {
+        enabled: true
+        config: {
+          logAnalyticsWorkspaceResourceID: logAnalytics.id
+        }
+      }
+    }
+  }
+}
+
+output resourceGroupName string = rg.name
+output clusterName string = aks.name


### PR DESCRIPTION
## Summary
- add a script `deploy_overlay.py` that provisions the AKS overlay cluster using the Azure Python SDK
- document how to use the Python script alongside the existing Bash and Bicep examples

## Testing
- `python3 -m py_compile examples/overlay-cni-public/deploy_overlay.py`


------
https://chatgpt.com/codex/tasks/task_e_686a4f4f01348321bc036725e064a1a0